### PR TITLE
Profiling - Changelog 1

### DIFF
--- a/src/core/base.h
+++ b/src/core/base.h
@@ -2,8 +2,6 @@
 
 #ifdef PLATFORM_WINDOWS
 #define SOEP_FORCE_INLINE __forceinline
-#elif defined(PLATFORM_LINUX)
-#define SOEP_FORCE_INLINE __attribute__((always_inline)) inline
 #else
 #define SOEP_FORCE_INLINE inline
 #endif

--- a/src/core/timer.h
+++ b/src/core/timer.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "base.h"
+#include <chrono>
+#include <unordered_map>
 #include <spdlog/spdlog.h>
 
 namespace SOEP {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,8 @@
 
 int main()
 {
-	SOEP::SOEP_SCOPE_TIMER("Main function");
+	spdlog::set_level(spdlog::level::trace);
+	SOEP::SOEP_SCOPE_TIMER("Main function"); // A timer that will end once scope has ended (a scope is everything within a block of {})
 	dotenv::init();
 	SOEP::Network::Init();
 	SOEP::ThreadPool pool{ 10 };


### PR DESCRIPTION
- Added a scoped timer that will print the time it took for the scope to complete automatically. Just place ```SOEP_SCOPE_TIMER("<some name>")```at the beginning of your scope
- Added a verify that works like asserts but doesn't go away on release builds (use sparingly)